### PR TITLE
Add schedule method only in EJB context constraint

### DIFF
--- a/src/main/resources/META-INF/jqassistant-rules/ejb3.xml
+++ b/src/main/resources/META-INF/jqassistant-rules/ejb3.xml
@@ -8,6 +8,7 @@
         <includeConcept refId="ejb3:Local"/>
         <includeConcept refId="ejb3:Remote"/>
         <includeConcept refId="ejb3:Schedule"/>
+        <includeConstraint refId="ejb3:ScheduleMethodInEjbContext"/>
     </group>
 
     <concept id="ejb3:StatelessSessionBean">
@@ -41,7 +42,8 @@
     </concept>
 
     <concept id="ejb3:MessageDrivenBean">
-        <description>Labels all types annotated with @javax.ejb.MessageDriven with "Ejb" and "MessageDriven".</description>
+        <description>Labels all types annotated with @javax.ejb.MessageDriven with "Ejb" and "MessageDriven".
+        </description>
         <cypher><![CDATA[
             MATCH (t:Type)-[:ANNOTATED_BY]->()-[:OF_TYPE]->(a:Type)
             WHERE a.fqn="javax.ejb.MessageDriven"
@@ -79,5 +81,18 @@
             RETURN m AS ScheduledMethod
         ]]></cypher>
     </concept>
+
+    <constraint id="ejb3:ScheduleMethodInEjbContext">
+        <requiresConcept refId="ejb3:StatelessSessionBean"/>
+        <requiresConcept refId="ejb3:StatefulSessionBean"/>
+        <requiresConcept refId="ejb3:SingletonBean"/>
+        <requiresConcept refId="ejb3:Schedule"/>
+        <description>Check that Schedule methods are only delared in EJB classes.</description>
+        <cypher><![CDATA[
+            MATCH (c:Class)-[:DECLARES]->(m:Method:Schedule)
+            WHERE NOT c:Ejb
+            RETURN c.fqn AS invalidBean, m.name AS scheduledMethodName
+        ]]></cypher>
+    </constraint>
 
 </jqa:jqassistant-rules>

--- a/src/test/java/com/buschmais/jqassistant/plugin/ejb3/test/Ejb3IT.java
+++ b/src/test/java/com/buschmais/jqassistant/plugin/ejb3/test/Ejb3IT.java
@@ -1,20 +1,28 @@
 package com.buschmais.jqassistant.plugin.ejb3.test;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 import com.buschmais.jqassistant.core.analysis.api.Result;
+import com.buschmais.jqassistant.core.analysis.api.rule.Constraint;
 import com.buschmais.jqassistant.core.analysis.api.rule.RuleException;
 import com.buschmais.jqassistant.plugin.ejb3.test.set.beans.*;
 import com.buschmais.jqassistant.plugin.java.test.AbstractJavaPluginIT;
 
-import org.apache.commons.lang3.reflect.MethodUtils;
 import org.junit.Test;
 
+import static com.buschmais.jqassistant.core.analysis.api.Result.Status.FAILURE;
+import static com.buschmais.jqassistant.core.analysis.api.Result.Status.SUCCESS;
+import static com.buschmais.jqassistant.core.analysis.test.matcher.ConstraintMatcher.constraint;
 import static com.buschmais.jqassistant.plugin.java.test.matcher.TypeDescriptorMatcher.typeDescriptor;
 import static com.buschmais.jqassistant.plugin.java.test.matcher.MethodDescriptorMatcher.methodDescriptor;
+import static com.buschmais.jqassistant.core.analysis.test.matcher.ResultMatcher.result;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertThat;
 
 /**
@@ -31,7 +39,7 @@ public class Ejb3IT extends AbstractJavaPluginIT {
     @Test
     public void statelessSessionBean() throws Exception {
         scanClasses(StatelessLocalBean.class);
-        assertThat(applyConcept("ejb3:StatelessSessionBean").getStatus(), equalTo(Result.Status.SUCCESS));
+        assertThat(applyConcept("ejb3:StatelessSessionBean").getStatus(), equalTo(SUCCESS));
         store.beginTransaction();
         assertThat(query("MATCH (ejb:Type:Stateless:Ejb) RETURN ejb").getColumn("ejb"), hasItem(typeDescriptor(StatelessLocalBean.class)));
         store.commitTransaction();
@@ -46,7 +54,7 @@ public class Ejb3IT extends AbstractJavaPluginIT {
     @Test
     public void statefulSessionBean() throws Exception {
         scanClasses(StatefulBean.class);
-        assertThat(applyConcept("ejb3:StatefulSessionBean").getStatus(), equalTo(Result.Status.SUCCESS));
+        assertThat(applyConcept("ejb3:StatefulSessionBean").getStatus(), equalTo(SUCCESS));
         store.beginTransaction();
         assertThat(query("MATCH (ejb:Type:Stateful:Ejb) RETURN ejb").getColumn("ejb"), hasItem(typeDescriptor(StatefulBean.class)));
         store.commitTransaction();
@@ -61,7 +69,7 @@ public class Ejb3IT extends AbstractJavaPluginIT {
     @Test
     public void singletonBean() throws Exception {
         scanClasses(SingletonBean.class);
-        assertThat(applyConcept("ejb3:SingletonBean").getStatus(), equalTo(Result.Status.SUCCESS));
+        assertThat(applyConcept("ejb3:SingletonBean").getStatus(), equalTo(SUCCESS));
         store.beginTransaction();
         assertThat(query("MATCH (ejb:Type:Singleton:Ejb) RETURN ejb").getColumn("ejb"), hasItem(typeDescriptor(SingletonBean.class)));
         store.commitTransaction();
@@ -76,7 +84,7 @@ public class Ejb3IT extends AbstractJavaPluginIT {
     @Test
     public void messageDrivenBean() throws Exception {
         scanClasses(MessageDrivenBean.class);
-        assertThat(applyConcept("ejb3:MessageDrivenBean").getStatus(), equalTo(Result.Status.SUCCESS));
+        assertThat(applyConcept("ejb3:MessageDrivenBean").getStatus(), equalTo(SUCCESS));
         store.beginTransaction();
         assertThat(query("MATCH (ejb:Type:MessageDriven:Ejb) RETURN ejb").getColumn("ejb"), hasItem(typeDescriptor(MessageDrivenBean.class)));
         store.commitTransaction();
@@ -91,7 +99,7 @@ public class Ejb3IT extends AbstractJavaPluginIT {
     @Test
     public void localSessionBean() throws Exception {
         scanClasses(StatelessLocalBean.class);
-        assertThat(applyConcept("ejb3:Local").getStatus(), equalTo(Result.Status.SUCCESS));
+        assertThat(applyConcept("ejb3:Local").getStatus(), equalTo(SUCCESS));
         store.beginTransaction();
         assertThat(query("MATCH (ejb:Type:Local:Ejb) RETURN ejb").getColumn("ejb"), hasItem(typeDescriptor(StatelessLocalBean.class)));
         store.commitTransaction();
@@ -106,7 +114,7 @@ public class Ejb3IT extends AbstractJavaPluginIT {
     @Test
     public void remoteSessionBean() throws Exception {
         scanClasses(StatelessRemoteBean.class);
-        assertThat(applyConcept("ejb3:Remote").getStatus(), equalTo(Result.Status.SUCCESS));
+        assertThat(applyConcept("ejb3:Remote").getStatus(), equalTo(SUCCESS));
         store.beginTransaction();
         assertThat(query("MATCH (ejb:Type:Remote:Ejb) RETURN ejb").getColumn("ejb"), hasItem(typeDescriptor(StatelessRemoteBean.class)));
         store.commitTransaction();
@@ -141,9 +149,59 @@ public class Ejb3IT extends AbstractJavaPluginIT {
     @Test
     public void scheduleMethod() throws Exception {
         scanClasses(ScheduledBean.class);
-        assertThat(applyConcept("ejb3:Schedule").getStatus(), equalTo(Result.Status.SUCCESS));
+        assertThat(applyConcept("ejb3:Schedule").getStatus(), equalTo(SUCCESS));
         store.beginTransaction();
         assertThat(query("MATCH (timer:Method:Schedule) RETURN timer").getColumn("timer"), hasItem(methodDescriptor(ScheduledBean.class, "invokeTimer")));
+        store.commitTransaction();
+    }
+
+    /**
+     * Verifies the constraint "ejb3:ScheduleMethodInEjbContext" results in
+     * no violations when applied to valid beans.
+     *
+     * @throws java.io.IOException
+     *             If the test fails.
+     */
+    @Test
+    public void scheduleMethodWithoutEjb_No_Violation() throws Exception {
+        scanClasses(ScheduledEJB.class);
+        final String ruleName = "ejb3:ScheduleMethodInEjbContext";
+        assertThat(validateConstraint(ruleName).getStatus(), equalTo(SUCCESS));
+        store.beginTransaction();
+
+        final List<Result<Constraint>> constraintViolations = new ArrayList<>(reportWriter.getConstraintResults().values());
+        assertThat("Unexpected number of violated constraints", constraintViolations.size(), equalTo(1));
+        final Result<Constraint> result = constraintViolations.get(0);
+        assertThat("Expected constraint " + ruleName, result, result(constraint(ruleName)));
+        final List<Map<String, Object>> violatedBeans = result.getRows();
+        assertThat("Unexpected number of violations", violatedBeans.size(), equalTo(0));
+
+        store.commitTransaction();
+    }
+
+    /**
+     * Verifies the constraint "ejb3:ScheduleMethodInEjbContext".
+     *
+     * @throws java.io.IOException
+     *             If the test fails.
+     */
+    @Test
+    public void scheduleMethodWithoutEjb() throws Exception {
+        scanClasses(ScheduledBean.class);
+        final String ruleName = "ejb3:ScheduleMethodInEjbContext";
+        assertThat(validateConstraint(ruleName).getStatus(), equalTo(FAILURE));
+        store.beginTransaction();
+
+        final List<Result<Constraint>> constraintViolations = new ArrayList<>(reportWriter.getConstraintResults().values());
+        assertThat("Unexpected number of violated constraints", constraintViolations.size(), equalTo(1));
+        final Result<Constraint> result = constraintViolations.get(0);
+        assertThat("Expected constraint " + ruleName, result, result(constraint(ruleName)));
+
+        final List<Map<String, Object>> violations = result.getRows();
+        assertThat("Unexpected number of violations", violations, hasSize(1));
+        assertThat("Unexpected bean name", ScheduledBean.class.getName(), equalTo(violations.get(0).get("invalidBean")));
+        assertThat("Unexpected method name", "invokeTimer", equalTo(violations.get(0).get("scheduledMethodName")));
+
         store.commitTransaction();
     }
 }

--- a/src/test/java/com/buschmais/jqassistant/plugin/ejb3/test/set/beans/ScheduledEJB.java
+++ b/src/test/java/com/buschmais/jqassistant/plugin/ejb3/test/set/beans/ScheduledEJB.java
@@ -1,0 +1,15 @@
+package com.buschmais.jqassistant.plugin.ejb3.test.set.beans;
+
+import javax.ejb.Schedule;
+import javax.ejb.Singleton;
+
+/**
+ * A bean with a scheduled timer.
+ */
+@Singleton
+public class ScheduledEJB {
+
+    @Schedule
+    public void invokeTimer() {}
+
+}


### PR DESCRIPTION
I have created a constraint to validate that scheduled methods need an EJB context to work properly. Scheduled methods in other bean contexts like CDI will not be invoked by the container. I have seen this mistake a couple of times in practice.